### PR TITLE
Adds missing URL rewrites in `vercel.json` config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+yarn.lock

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #15 

Additionally adds `yarn.lock` to gitignore.